### PR TITLE
DefaultAzureCredentialにユーザー割り当てマネージド ID を指定する

### DIFF
--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -43,24 +43,6 @@ resource "azurerm_key_vault_secret" "default_from_email" {
   key_vault_id = azurerm_key_vault.app.id
 }
 
-resource "azurerm_key_vault_secret" "azure_client_id" {
-  name         = "AZURE-CLIENT-ID"
-  value        = var.azure_client_id
-  key_vault_id = azurerm_key_vault.app.id
-}
-
-resource "azurerm_key_vault_secret" "azure_tenant_id" {
-  name         = "AZURE-TENANT-ID"
-  value        = var.azure_tenant_id
-  key_vault_id = azurerm_key_vault.app.id
-}
-
-resource "azurerm_key_vault_secret" "azure_client_secret" {
-  name         = "AZURE-CLIENT-SECRET"
-  value        = var.azure_client_secret
-  key_vault_id = azurerm_key_vault.app.id
-}
-
 # Azure Cache for Redis
 resource "azurerm_key_vault_secret" "redis_host" {
   name         = "REDIS-HOST"

--- a/terraform/keyvault.tf
+++ b/terraform/keyvault.tf
@@ -43,6 +43,12 @@ resource "azurerm_key_vault_secret" "default_from_email" {
   key_vault_id = azurerm_key_vault.app.id
 }
 
+resource "azurerm_key_vault_secret" "webappcontainer_client_id" {
+  name         = "WEBAPPCONTAINER-CLIENT-ID"
+  value        = azurerm_user_assigned_identity.webappcontainer.client_id
+  key_vault_id = azurerm_key_vault.app.id
+}
+
 # Azure Cache for Redis
 resource "azurerm_key_vault_secret" "redis_host" {
   name         = "REDIS-HOST"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,16 +32,6 @@ variable "default_from_email" {
   type = string
 }
 
-variable "azure_client_id" {
-  type = string
-}
-variable "azure_tenant_id" {
-  type = string
-}
-variable "azure_client_secret" {
-  type = string
-}
-
 # Azure Storage
 variable "account_replication_type" {
   type    = string

--- a/terraform/webappcontainer.tf
+++ b/terraform/webappcontainer.tf
@@ -55,9 +55,6 @@ resource "azurerm_linux_web_app" "app" {
     "DJANGO_DEFAULT_FROM_EMAIL"           = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=DEFAULT-FROM-EMAIL)"
     "DJANGO_SECRET_KEY"                   = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=DJANGO-SECRET-KEY)"
     "APPINSIGHTS_CONNECTION_STRING"       = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=APPINSIGHTS-CONNECTION-STRING)"
-    "AZURE_CLIENT_ID"                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=AZURE-CLIENT-ID)"
-    "AZURE_TENANT_ID"                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=AZURE-TENANT-ID)"
-    "AZURE_CLIENT_SECRET"                 = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=AZURE-CLIENT-SECRET)"
   }
 
   # Use Key Vault references for App Service

--- a/terraform/webappcontainer.tf
+++ b/terraform/webappcontainer.tf
@@ -55,6 +55,7 @@ resource "azurerm_linux_web_app" "app" {
     "DJANGO_DEFAULT_FROM_EMAIL"           = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=DEFAULT-FROM-EMAIL)"
     "DJANGO_SECRET_KEY"                   = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=DJANGO-SECRET-KEY)"
     "APPINSIGHTS_CONNECTION_STRING"       = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=APPINSIGHTS-CONNECTION-STRING)"
+    "AZURE_CLIENT_ID"                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.app.name};SecretName=WEBAPPCONTAINER-CLIENT-ID)"
   }
 
   # Use Key Vault references for App Service


### PR DESCRIPTION
close #2 

# 概要
ユーザー割り当てマネージドIDを使用して `DefaultAzureCredential()` で認証する。

# 変更内容
App Serviceの環境変数 `AZURE_CLIENT_ID` にはユーザー割り当てマネージドIDの `client_id` を指定する必要がある。

- [Specify a user assigned managed identity for DefaultAzureCredential](https://learn.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#specify-a-user-assigned-managed-identity-for-defaultazurecredential)
- [DefaultAzureCredential Class](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential)