### PR TITLE
[fix]GitHubActionsのランナーのIP許可設定を追加

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Get runner's Public IP
+        id: ip
+        uses: haythem/public-ip@v1.2
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
@@ -48,6 +52,8 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
+        env:
+          TF_VAR_runner_public_ip: ${{ steps.ip.outputs.ipv4 }}
         run: terraform plan -no-color -input=false
         continue-on-error: true
 
@@ -57,4 +63,6 @@ jobs:
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        env:
+          TF_VAR_runner_public_ip: ${{ steps.ip.outputs.ipv4 }}
         run: terraform apply -auto-approve -input=false

--- a/terraform/infra/keyvault.tf
+++ b/terraform/infra/keyvault.tf
@@ -15,7 +15,11 @@ resource "azurerm_key_vault" "app" {
   network_acls {
     bypass         = "AzureServices"
     default_action = "Deny"
-    ip_rules       = var.allowed_cidr
+    ip_rules       = local.allowed_cidr
+  }
+
+  lifecycle {
+    ignore_changes = [network_acls[0].ip_rules]
   }
 }
 

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -35,6 +35,7 @@ resource "random_integer" "num" {
 
 locals {
   service_fqdn = "${var.custom_domain_host_name}.${var.dns_zone_name}"
+  allowed_cidr = concat(var.client_public_ip, [chomp(var.runner_public_ip)])
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -23,8 +23,12 @@ variable "location" {
   default = "japaneast"
 }
 
-variable "allowed_cidr" {
+variable "client_public_ip" {
   type = list(any)
+}
+
+variable "runner_public_ip" {
+  type = string
 }
 
 # Django app

--- a/terraform/trust/main.tf
+++ b/terraform/trust/main.tf
@@ -34,6 +34,14 @@ provider "github" {
 ##################################
 data "azurerm_subscription" "current" {}
 
+locals {
+  tfc_roles = [
+    "Contributor",
+    "Key Vault Administrator",
+    "User Access Administrator"
+  ]
+}
+
 resource "azuread_application" "tfc_application" {
   display_name = "terraform-cloud"
 }
@@ -43,9 +51,10 @@ resource "azuread_service_principal" "tfc_service_principal" {
 }
 
 resource "azurerm_role_assignment" "tfc_role_assignment" {
+  count                = length(local.tfc_roles)
   scope                = data.azurerm_subscription.current.id
   principal_id         = azuread_service_principal.tfc_service_principal.object_id
-  role_definition_name = "Contributor"
+  role_definition_name = local.tfc_roles[count.index]
 }
 
 resource "azuread_application_federated_identity_credential" "tfc_federated_credential_plan" {
@@ -112,9 +121,9 @@ resource "tfe_variable" "azure_tenant_id" {
   sensitive    = true
 }
 
-resource "tfe_variable" "allowed_cidr" {
-  key          = "allowed_cidr"
-  value        = jsonencode(var.allowed_cidr)
+resource "tfe_variable" "client_public_ip" {
+  key          = "client_public_ip"
+  value        = jsonencode(var.client_public_ip)
   category     = "terraform"
   workspace_id = tfe_workspace.infra.id
   sensitive    = true

--- a/terraform/trust/variables.tf
+++ b/terraform/trust/variables.tf
@@ -39,7 +39,7 @@ variable "tfc_encrypted_token" {
 }
 
 # Application and Infrastructure
-variable "allowed_cidr" {
+variable "client_public_ip" {
   type = list(any)
 }
 


### PR DESCRIPTION
- ワークフロー内でランナーのパブリックIPを取得してTerraformの変数に渡す
- KeyVaultのACLに設定しているallow_cidrのリストにランナーのIPが追加されるようにする
- ユーザー割り当てマネージドIDにロール割り当てできるように「ユーザーアクセス管理者」の権限を追加