### PR TITLE
[fix]TerraformCloudのIP許可設定を追加

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Get runner's Public IP
-        id: ip
-        uses: haythem/public-ip@v1.2
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
@@ -52,8 +48,6 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: github.event_name == 'pull_request'
-        env:
-          TF_VAR_runner_public_ip: ${{ steps.ip.outputs.ipv4 }}
         run: terraform plan -no-color -input=false
         continue-on-error: true
 
@@ -63,6 +57,4 @@ jobs:
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          TF_VAR_runner_public_ip: ${{ steps.ip.outputs.ipv4 }}
         run: terraform apply -auto-approve -input=false

--- a/terraform/infra/.terraform.lock.hcl
+++ b/terraform/infra/.terraform.lock.hcl
@@ -21,6 +21,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.3.0"
+  hashes = [
+    "h1:pK/CC2NlpUbL4x3R386uxfS80HodJXtGREg0k2ABukw=",
+    "zh:27d101f4c089d1e367bbbbb3f260fc7d52f63559a4424c08633e566863c951b2",
+    "zh:37860671324229f52a7d82eea88a31fe24321297fd699d879de5b6cf6aae086c",
+    "zh:4680716579e361298e4331ce0c92e38011fc41ed56bd55302c23b696b3b8c469",
+    "zh:547cd2a407ca0d22307634d83ffc64cd4225f221baa09682b7a8c5a2429c34d8",
+    "zh:61965698af75aad7482f2f593b75f15e4a4f6f0117b643c69f3da61f40b1a9c7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93f9e0f2244816cbb72197c733ada4214df691e4e6a84b8e340e43e43ab8a383",
+    "zh:969aad70624d033c257c365cf75001d29fa7341b48d673cd7317205395b4791b",
+    "zh:e9504018b1af992c041bda1e4a6f01db1f1cdb1a7df8055d1082049befbc4217",
+    "zh:fa7f6af94e75c6fe21782c622ed387ae08ee3ffeaa0176f08d0b06bb61bb50f4",
+    "zh:feda1d7cdae86bce829f82223f625b55c858a36d3aca1a762d7258798a25b476",
+    "zh:ff1f3d8c53930aad2fde32d6328df7e7e5b5de36dd7c0682d15518993ab199ef",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -25,17 +25,23 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
-
 }
+
+provider "http" {}
 
 resource "random_integer" "num" {
   min = 10000
   max = 99999
 }
 
+data "http" "ipify" {
+  url = "http://api.ipify.org"
+}
+
 locals {
-  service_fqdn = "${var.custom_domain_host_name}.${var.dns_zone_name}"
-  allowed_cidr = concat(var.client_public_ip, [chomp(var.runner_public_ip)])
+  service_fqdn  = "${var.custom_domain_host_name}.${var.dns_zone_name}"
+  tfc_public_ip = chomp(data.http.ipify.response_body)
+  allowed_cidr  = concat(var.client_public_ip, [local.tfc_public_ip])
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -27,10 +27,6 @@ variable "client_public_ip" {
   type = list(any)
 }
 
-variable "runner_public_ip" {
-  type = string
-}
-
 # Django app
 variable "secret_key" {
   type = string


### PR DESCRIPTION
- GitHubActionsのランナーのIP許可設定を削除
- ipifyのAPIをコールしてTerraform実行環境のパブリックIPを取得するよう修正