### PR TITLE
[Fix]bug fix

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,35 +50,35 @@ jobs:
         run: terraform plan -no-color -input=false
         continue-on-error: true
 
-      - name: Update Pull Request
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+      # - name: Update Pull Request
+      #   uses: actions/github-script@v6
+      #   if: github.event_name == 'pull_request'
+      #   env:
+      #     PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+      #       #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+      #       #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+      #       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
 
-            <details><summary>Show Plan</summary>
+      #       <details><summary>Show Plan</summary>
 
-            \`\`\`\n
-            ${process.env.PLAN}
-            \`\`\`
+      #       \`\`\`\n
+      #       ${process.env.PLAN}
+      #       \`\`\`
 
-            </details>
+      #       </details>
 
-            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+      #       *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
+      #       github.rest.issues.createComment({
+      #         issue_number: context.issue.number,
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         body: output
+      #       })
 
       - name: Terraform Plan Status
         if: steps.plan.outcome == 'failure'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,8 +13,8 @@ on:
       - ".github/workflows/terraform.yml"
   workflow_dispatch:
 
-permissions:
-  pull-requests: write
+# permissions:
+#   pull-requests: write
 
 jobs:
   terraform:

--- a/terraform/infra/aad.tf
+++ b/terraform/infra/aad.tf
@@ -1,8 +1,6 @@
 ################################
 # User Assigned Managed ID
 ################################
-data "azurerm_subscription" "primary" {}
-
 resource "azurerm_user_assigned_identity" "webappcontainer" {
   name                = "${var.prefix}-${var.env}-webappcontainer-mngid"
   resource_group_name = azurerm_resource_group.rg.name

--- a/terraform/infra/keyvault.tf
+++ b/terraform/infra/keyvault.tf
@@ -11,12 +11,6 @@ resource "azurerm_key_vault" "app" {
   purge_protection_enabled   = false
   soft_delete_retention_days = 7
   access_policy              = []
-
-  network_acls {
-    bypass         = "AzureServices"
-    default_action = "Deny"
-    ip_rules       = var.allowed_cidr
-  }
 }
 
 ################################

--- a/terraform/infra/keyvault.tf
+++ b/terraform/infra/keyvault.tf
@@ -1,14 +1,12 @@
 ################################
 # Key Vault
 ################################
-data "azurerm_client_config" "current" {}
-
 resource "azurerm_key_vault" "app" {
   name                       = "${var.prefix}-${var.env}-vault"
   resource_group_name        = azurerm_resource_group.rg.name
   location                   = azurerm_resource_group.rg.location
   sku_name                   = "standard"
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  tenant_id                  = data.azurerm_subscription.primary.tenant_id
   enable_rbac_authorization  = true
   purge_protection_enabled   = false
   soft_delete_retention_days = 7

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -25,8 +25,9 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
-
 }
+
+data "azurerm_subscription" "primary" {}
 
 resource "random_integer" "num" {
   min = 10000

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -15,10 +15,6 @@ variable "location" {
   default = "japaneast"
 }
 
-variable "allowed_cidr" {
-  type = list(any)
-}
-
 # Django app
 variable "secret_key" {
   type = string

--- a/terraform/trust/main.tf
+++ b/terraform/trust/main.tf
@@ -34,6 +34,14 @@ provider "github" {
 ##################################
 data "azurerm_subscription" "current" {}
 
+locals {
+  tfc_roles = [
+    "Contributor",
+    "Key Vault Administrator",
+    "User Access Administrator"
+  ]
+}
+
 resource "azuread_application" "tfc_application" {
   display_name = "terraform-cloud"
 }
@@ -43,9 +51,10 @@ resource "azuread_service_principal" "tfc_service_principal" {
 }
 
 resource "azurerm_role_assignment" "tfc_role_assignment" {
+  count                = length(local.tfc_roles)
   scope                = data.azurerm_subscription.current.id
   principal_id         = azuread_service_principal.tfc_service_principal.object_id
-  role_definition_name = "Contributor"
+  role_definition_name = local.tfc_roles[count.index]
 }
 
 resource "azuread_application_federated_identity_credential" "tfc_federated_credential_plan" {

--- a/terraform/trust/main.tf
+++ b/terraform/trust/main.tf
@@ -121,15 +121,6 @@ resource "tfe_variable" "azure_tenant_id" {
   sensitive    = true
 }
 
-resource "tfe_variable" "allowed_cidr" {
-  key          = "allowed_cidr"
-  value        = jsonencode(var.allowed_cidr)
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-  hcl          = true
-}
-
 resource "tfe_variable" "secret_key" {
   key          = "secret_key"
   value        = var.secret_key

--- a/terraform/trust/variables.tf
+++ b/terraform/trust/variables.tf
@@ -39,10 +39,6 @@ variable "tfc_encrypted_token" {
 }
 
 # Application and Infrastructure
-variable "allowed_cidr" {
-  type = list(any)
-}
-
 variable "secret_key" {
   type = string
 }


### PR DESCRIPTION
- KeyVaultのシークレット書き込み、マネージドIDへのロール割り当てができるようにサービスプリンシパルの権限を追加
  - キーコンテナー管理者
  - ユーザーアクセス管理者
- KeyVaultのネットワークACL設定を削除（Terraform CloudからのパブリックIPを許可する方法が現時点では不明なため）
- TenantIDの参照方法を`data.azurerm_subscription`に統一
- Terraform Planの結果をPull Requestへ投稿しないよう修正（ログに機密情報を含むため）