### PR TITLE
[update]Terraform実行環境をGitHub Actionsへ変更

### DIFF
--- a/.github/workflows/terraform-cloud.yml
+++ b/.github/workflows/terraform-cloud.yml
@@ -1,0 +1,93 @@
+# name: "Terraform Cloud"
+
+# on:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - "terraform/infra/**"
+#       - ".github/workflows/terraform-cloud.yml"
+#   pull_request:
+#     paths:
+#       - "terraform/infra/**"
+#       - ".github/workflows/terraform-cloud.yml"
+#   workflow_dispatch:
+
+# # permissions:
+# #   pull-requests: write
+
+# jobs:
+#   terraform:
+#     name: "Terraform - ${{ matrix.envs }}"
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         envs: [dev]
+#     defaults:
+#       run:
+#         working-directory: ./terraform/infra/envs/${{ matrix.envs }}
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v3
+
+#       - name: Setup Terraform
+#         uses: hashicorp/setup-terraform@v2
+#         with:
+#           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+#       - name: Terraform Format
+#         id: fmt
+#         run: terraform fmt -check
+#         working-directory: ./terraform/infra
+
+#       - name: Terraform Init
+#         id: init
+#         run: terraform init
+
+#       - name: Terraform Validate
+#         id: validate
+#         run: terraform validate -no-color
+
+#       - name: Terraform Plan
+#         id: plan
+#         if: github.event_name == 'pull_request'
+#         run: terraform plan -no-color -input=false
+#         continue-on-error: true
+
+#       # - name: Update Pull Request
+#       #   uses: actions/github-script@v6
+#       #   if: github.event_name == 'pull_request'
+#       #   env:
+#       #     PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+#       #   with:
+#       #     github-token: ${{ secrets.GITHUB_TOKEN }}
+#       #     script: |
+#       #       const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+#       #       #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+#       #       #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+#       #       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+#       #       <details><summary>Show Plan</summary>
+
+#       #       \`\`\`\n
+#       #       ${process.env.PLAN}
+#       #       \`\`\`
+
+#       #       </details>
+
+#       #       *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+#       #       github.rest.issues.createComment({
+#       #         issue_number: context.issue.number,
+#       #         owner: context.repo.owner,
+#       #         repo: context.repo.repo,
+#       #         body: output
+#       #       })
+
+#       - name: Terraform Plan Status
+#         if: steps.plan.outcome == 'failure'
+#         run: exit 1
+
+#       - name: Terraform Apply
+#         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+#         run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,6 +33,8 @@ jobs:
   terraform:
     name: "Terraform - ${{ matrix.envs }}"
     runs-on: ubuntu-latest
+    environment:
+      name: development
     strategy:
       matrix:
         envs: [dev]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   TF_VERSION: 1.5.3
-  TF_VAR_allowed_cidr: ${ secrets.ALLOWED_CIDR}
+  TF_VAR_allowed_cidr: ${ secrets.ALLOWED_CIDR }
   TF_VAR_secret_key: ${ secrets.SECRET_KEY }
   TF_VAR_sendgrid_api_key: ${ secrets.SENDGRID_API_KEY }
   TF_VAR_default_from_email: ${ secrets.DEFAULT_FROM_EMAIL }

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,14 +20,14 @@ permissions:
 
 env:
   TF_VERSION: 1.5.3
-  TF_VAR_allowed_cidr: ${ secrets.ALLOWED_CIDR }
-  TF_VAR_secret_key: ${ secrets.SECRET_KEY }
-  TF_VAR_sendgrid_api_key: ${ secrets.SENDGRID_API_KEY }
-  TF_VAR_default_from_email: ${ secrets.DEFAULT_FROM_EMAIL }
-  TF_VAR_db_username: ${ secrets.DB_USERNAME }
-  TF_VAR_db_password: ${ secrets.DB_PASSWORD }
-  TF_VAR_vm_admin_username: ${ secrets.VM_ADMIN_USERNAME }
-  TF_VAR_public_key: ${ secrets.PUBLIC_KEY }
+  TF_VAR_allowed_cidr: ${{ secrets.ALLOWED_CIDR }}
+  TF_VAR_secret_key: ${{ secrets.SECRET_KEY }}
+  TF_VAR_sendgrid_api_key: ${{ secrets.SENDGRID_API_KEY }}
+  TF_VAR_default_from_email: ${{ secrets.DEFAULT_FROM_EMAIL }}
+  TF_VAR_db_username: ${{ secrets.DB_USERNAME }}
+  TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
+  TF_VAR_vm_admin_username: ${{ secrets.VM_ADMIN_USERNAME }}
+  TF_VAR_public_key: ${{ secrets.PUBLIC_KEY }}
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,6 +16,17 @@ on:
 # permissions:
 #   pull-requests: write
 
+env:
+  TF_VERSION: 1.5.3
+  TF_VAR_allowed_cidr: ${ secrets.ALLOWED_CIDR}
+  TF_VAR_secret_key: ${ secrets.SECRET_KEY }
+  TF_VAR_sendgrid_api_key: ${ secrets.SENDGRID_API_KEY }
+  TF_VAR_default_from_email: ${ secrets.DEFAULT_FROM_EMAIL }
+  TF_VAR_db_username: ${ secrets.DB_USERNAME }
+  TF_VAR_db_password: ${ secrets.DB_PASSWORD }
+  TF_VAR_vm_admin_username: ${ secrets.VM_ADMIN_USERNAME }
+  TF_VAR_public_key: ${ secrets.PUBLIC_KEY }
+
 jobs:
   terraform:
     name: "Terraform - ${{ matrix.envs }}"
@@ -33,7 +44,14 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform Format
         id: fmt

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,7 +13,9 @@ on:
       - ".github/workflows/terraform.yml"
   workflow_dispatch:
 
-# permissions:
+permissions:
+  id-token: write
+  contents: read
 #   pull-requests: write
 
 env:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,17 +45,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
       - name: Azure Login
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Format
         id: fmt
@@ -65,6 +65,11 @@ jobs:
       - name: Terraform Init
         id: init
         run: terraform init
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: true
 
       - name: Terraform Validate
         id: validate
@@ -75,6 +80,11 @@ jobs:
         if: github.event_name == 'pull_request'
         run: terraform plan -no-color -input=false
         continue-on-error: true
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: true
 
       # - name: Update Pull Request
       #   uses: actions/github-script@v6
@@ -113,3 +123,8 @@ jobs:
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform apply -auto-approve -input=false
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: true

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,0 +1,10 @@
+version: 3
+automerge: true
+projects:
+  - name: development
+    dir: terraform/infra/envs/dev
+    workspace: default
+    terraform_version: v1.5.5
+    autoplan:
+      enabled: true
+      when_modified: ["*.tf", "../../modules/**/*.tf"]

--- a/terraform/infra/envs/dev/.terraform.lock.hcl
+++ b/terraform/infra/envs/dev/.terraform.lock.hcl
@@ -21,6 +21,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.4.0"
+  hashes = [
+    "h1:h3URn6qAnP36OlSqI1tTuKgPL3GriZaJia9ZDrUvRdg=",
+    "zh:56712497a87bc4e91bbaf1a5a2be4b3f9cfa2384baeb20fc9fad0aff8f063914",
+    "zh:6661355e1090ebacab16a40ede35b029caffc279d67da73a000b6eecf0b58eba",
+    "zh:67b92d343e808b92d7e6c3bbcb9b9d5475fecfed0836963f7feb9d9908bd4c4f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86ebb9be9b685c96dbb5c024b55d87526d57a4b127796d6046344f8294d3f28e",
+    "zh:902be7cfca4308cba3e1e7ba6fc292629dfd150eb9a9f054a854fa1532b0ceba",
+    "zh:9ba26e0215cd53b21fe26a0a98c007de1348b7d13a75ae3cfaf7729e0f2c50bb",
+    "zh:a195c941e1f1526147134c257ff549bea4c89c953685acd3d48d9de7a38f39dc",
+    "zh:a7967b3d2a8c3e7e1dc9ae381ca753268f9fce756466fe2fc9e414ca2d85a92e",
+    "zh:bde56542e9a093434d96bea21c341285737c6d38fea2f05e12ba7b333f3e9c05",
+    "zh:c0306f76903024c497fd01f9fd9bace5854c263e87a97bc2e89dcc96d35ca3cc",
+    "zh:f9335a6c336171e85f8e3e99c3d31758811a19aeb21fa8c9013d427e155ae2a9",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = "~> 3.5.1"

--- a/terraform/infra/envs/dev/backend.tf
+++ b/terraform/infra/envs/dev/backend.tf
@@ -1,9 +1,8 @@
 terraform {
-  cloud {
-    organization = "m-oka-system"
-
-    workspaces {
-      name = "azphoto"
-    }
+  backend "azurerm" {
+    resource_group_name  = "tfstate"
+    storage_account_name = "tfstate28226"
+    container_name       = "azphoto"
+    key                  = "dev.terraform.tfstate"
   }
 }

--- a/terraform/infra/envs/dev/backend.tf
+++ b/terraform/infra/envs/dev/backend.tf
@@ -4,6 +4,5 @@ terraform {
     storage_account_name = "tfstate28226"
     container_name       = "azphoto"
     key                  = "dev.terraform.tfstate"
-    use_oidc             = true
   }
 }

--- a/terraform/infra/envs/dev/backend.tf
+++ b/terraform/infra/envs/dev/backend.tf
@@ -4,5 +4,6 @@ terraform {
     storage_account_name = "tfstate28226"
     container_name       = "azphoto"
     key                  = "dev.terraform.tfstate"
+    use_oidc             = true
   }
 }

--- a/terraform/infra/envs/dev/locals.tf
+++ b/terraform/infra/envs/dev/locals.tf
@@ -1,8 +1,9 @@
 locals {
   common = {
-    subscription_id = data.azurerm_subscription.primary.subscription_id
-    tenant_id       = data.azurerm_subscription.primary.tenant_id
-    random          = random_integer.num.result
+    subscription_id   = data.azurerm_subscription.primary.subscription_id
+    tenant_id         = data.azurerm_subscription.primary.tenant_id
+    random            = random_integer.num.result
+    client_ip_address = chomp(data.http.ipify.response_body)
   }
 
   key_vault = {

--- a/terraform/infra/envs/dev/main.tf
+++ b/terraform/infra/envs/dev/main.tf
@@ -13,8 +13,6 @@ terraform {
 }
 
 provider "azurerm" {
-  use_oidc = true
-
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/terraform/infra/envs/dev/main.tf
+++ b/terraform/infra/envs/dev/main.tf
@@ -13,6 +13,8 @@ terraform {
 }
 
 provider "azurerm" {
+  use_oidc = true
+
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/terraform/infra/envs/dev/main.tf
+++ b/terraform/infra/envs/dev/main.tf
@@ -20,6 +20,12 @@ provider "azurerm" {
   }
 }
 
+provider "http" {}
+
+data "http" "ipify" {
+  url = "http://api.ipify.org"
+}
+
 data "azurerm_subscription" "primary" {}
 
 resource "random_integer" "num" {
@@ -96,6 +102,7 @@ module "storage" {
   storage             = var.storage
   blob_container      = var.blob_container
   allowed_cidr        = var.allowed_cidr
+  client_ip_address   = local.common.client_ip_address
 }
 
 module "key_vault" {
@@ -105,6 +112,7 @@ module "key_vault" {
   resource_group_name = module.resource_group.resource_group_name
   key_vault           = var.key_vault
   allowed_cidr        = var.allowed_cidr
+  client_ip_address   = local.common.client_ip_address
   tenant_id           = local.common.tenant_id
 }
 

--- a/terraform/infra/envs/dev/variables.tf
+++ b/terraform/infra/envs/dev/variables.tf
@@ -8,7 +8,7 @@ variable "common" {
 }
 
 variable "allowed_cidr" {
-  type = list(string)
+  type = string
 }
 
 variable "secret_key" {

--- a/terraform/infra/modules/app_service/app_service.tf
+++ b/terraform/infra/modules/app_service/app_service.tf
@@ -45,7 +45,7 @@ resource "azurerm_linux_web_app" "this" {
         name        = ip_restriction.value.name
         priority    = ip_restriction.value.priority
         action      = ip_restriction.value.action
-        ip_address  = lookup(ip_restriction.value, "ip_address", null) == "MyIP" ? join(",", var.allowed_cidr) : lookup(ip_restriction.value, "ip_address", null)
+        ip_address  = lookup(ip_restriction.value, "ip_address", null) == "MyIP" ? var.allowed_cidr : lookup(ip_restriction.value, "ip_address", null)
         service_tag = ip_restriction.value.service_tag
 
         dynamic "headers" {
@@ -70,7 +70,7 @@ resource "azurerm_linux_web_app" "this" {
         name        = scm_ip_restriction.value.name
         priority    = scm_ip_restriction.value.priority
         action      = scm_ip_restriction.value.action
-        ip_address  = lookup(scm_ip_restriction.value, "ip_address", null) == "MyIP" ? join(",", var.allowed_cidr) : lookup(scm_ip_restriction.value, "ip_address", null)
+        ip_address  = lookup(scm_ip_restriction.value, "ip_address", null) == "MyIP" ? var.allowed_cidr : lookup(scm_ip_restriction.value, "ip_address", null)
         service_tag = scm_ip_restriction.value.service_tag
       }
     }

--- a/terraform/infra/modules/frontdoor/frontdoor.tf
+++ b/terraform/infra/modules/frontdoor/frontdoor.tf
@@ -176,7 +176,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "this" {
         match_variable     = "RemoteAddr"
         operator           = "IPMatch"
         negation_condition = true # 含まない場合
-        match_values       = join(",", lookup(custom_rule.value, "match_values", null)) == "MyIP" ? var.allowed_cidr : lookup(custom_rule.value, "match_values", null)
+        match_values       = join(",", lookup(custom_rule.value, "match_values", null)) == "MyIP" ? split(",", var.allowed_cidr) : lookup(custom_rule.value, "match_values", null)
       }
     }
   }

--- a/terraform/infra/modules/key_vault/key_vault.tf
+++ b/terraform/infra/modules/key_vault/key_vault.tf
@@ -16,7 +16,7 @@ resource "azurerm_key_vault" "this" {
   network_acls {
     default_action             = each.value.network_acls.default_action
     bypass                     = each.value.network_acls.bypass
-    ip_rules                   = join(",", lookup(each.value.network_acls, "ip_rules", null)) == "MyIP" ? var.allowed_cidr : lookup(each.value.network_acls, "ip_rules", null)
+    ip_rules                   = join(",", lookup(each.value.network_acls, "ip_rules", null)) == "MyIP" ? toset(concat(split(",", var.allowed_cidr), [var.client_ip_address])) : lookup(each.value.network_acls, "ip_rules", null)
     virtual_network_subnet_ids = each.value.network_acls.virtual_network_subnet_ids
   }
 }

--- a/terraform/infra/modules/key_vault/variables.tf
+++ b/terraform/infra/modules/key_vault/variables.tf
@@ -2,4 +2,5 @@ variable "common" {}
 variable "resource_group_name" {}
 variable "key_vault" {}
 variable "allowed_cidr" {}
+variable "client_ip_address" {}
 variable "tenant_id" {}

--- a/terraform/infra/modules/network_security_group/network_security_group.tf
+++ b/terraform/infra/modules/network_security_group/network_security_group.tf
@@ -19,7 +19,7 @@ resource "azurerm_network_security_group" "this" {
       source_port_range          = lookup(security_rule.value, "source_port_range", null)
       destination_port_range     = lookup(security_rule.value, "destination_port_range", null)
       source_address_prefix      = lookup(security_rule.value, "source_address_prefix", null)
-      source_address_prefixes    = join(",", lookup(security_rule.value, "source_address_prefixes", null)) == "MyIP" ? var.allowed_cidr : lookup(security_rule.value, "source_address_prefixes", null)
+      source_address_prefixes    = join(",", lookup(security_rule.value, "source_address_prefixes", null)) == "MyIP" ? split(",", var.allowed_cidr) : lookup(security_rule.value, "source_address_prefixes", null)
       destination_address_prefix = lookup(security_rule.value, "destination_address_prefix", null)
     }
   }

--- a/terraform/infra/modules/storage/storage.tf
+++ b/terraform/infra/modules/storage/storage.tf
@@ -31,7 +31,7 @@ resource "azurerm_storage_account" "this" {
   network_rules {
     default_action             = each.value.network_rules.default_action
     bypass                     = each.value.network_rules.bypass
-    ip_rules                   = join(",", lookup(each.value.network_rules, "ip_rules", null)) == "MyIP" ? var.allowed_cidr : lookup(each.value.network_rules, "ip_rules", null)
+    ip_rules                   = join(",", lookup(each.value.network_rules, "ip_rules", null)) == "MyIP" ? toset(concat(split(",", var.allowed_cidr), [var.client_ip_address])) : lookup(each.value.network_rules, "ip_rules", null)
     virtual_network_subnet_ids = each.value.network_rules.virtual_network_subnet_ids
   }
 }

--- a/terraform/infra/modules/storage/variables.tf
+++ b/terraform/infra/modules/storage/variables.tf
@@ -4,3 +4,4 @@ variable "random" {}
 variable "storage" {}
 variable "blob_container" {}
 variable "allowed_cidr" {}
+variable "client_ip_address" {}

--- a/terraform/trust/main.tf
+++ b/terraform/trust/main.tf
@@ -83,115 +83,172 @@ data "tfe_organization" "org" {
 resource "tfe_workspace" "infra" {
   name                  = var.tfc_workspace_name
   organization          = data.tfe_organization.org.name
-  working_directory     = "envs/dev"
   auto_apply            = false
   file_triggers_enabled = false
   queue_all_runs        = false
-  execution_mode        = "remote"
+  execution_mode        = "local"
 }
 
-# Workspace variables
-resource "tfe_variable" "azure_provider_auth" {
-  key          = "TFC_AZURE_PROVIDER_AUTH"
-  value        = true
-  category     = "env"
-  workspace_id = tfe_workspace.infra.id
-}
+# resource "tfe_workspace" "infra" {
+#   name                  = var.tfc_workspace_name
+#   organization          = data.tfe_organization.org.name
+#   working_directory     = "envs/dev"
+#   auto_apply            = false
+#   file_triggers_enabled = false
+#   queue_all_runs        = false
+#   execution_mode        = "remote"
+# }
 
-resource "tfe_variable" "azure_client_id" {
-  key          = "TFC_AZURE_RUN_CLIENT_ID"
-  value        = azuread_application.tfc_application.application_id
-  category     = "env"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# # Workspace variables
+# resource "tfe_variable" "azure_provider_auth" {
+#   key          = "TFC_AZURE_PROVIDER_AUTH"
+#   value        = true
+#   category     = "env"
+#   workspace_id = tfe_workspace.infra.id
+# }
 
-resource "tfe_variable" "azure_subscription_id" {
-  key          = "ARM_SUBSCRIPTION_ID"
-  value        = data.azurerm_subscription.current.subscription_id
-  category     = "env"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "azure_client_id" {
+#   key          = "TFC_AZURE_RUN_CLIENT_ID"
+#   value        = azuread_application.tfc_application.application_id
+#   category     = "env"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "azure_tenant_id" {
-  key          = "ARM_TENANT_ID"
-  value        = data.azurerm_subscription.current.tenant_id
-  category     = "env"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "azure_subscription_id" {
+#   key          = "ARM_SUBSCRIPTION_ID"
+#   value        = data.azurerm_subscription.current.subscription_id
+#   category     = "env"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "allowed_cidr" {
-  key          = "allowed_cidr"
-  value        = jsonencode(var.allowed_cidr)
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-  hcl          = true
-}
+# resource "tfe_variable" "azure_tenant_id" {
+#   key          = "ARM_TENANT_ID"
+#   value        = data.azurerm_subscription.current.tenant_id
+#   category     = "env"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "secret_key" {
-  key          = "secret_key"
-  value        = var.secret_key
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "allowed_cidr" {
+#   key          = "allowed_cidr"
+#   value        = jsonencode(var.allowed_cidr)
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+#   hcl          = true
+# }
 
-resource "tfe_variable" "sendgrid_api_key" {
-  key          = "sendgrid_api_key"
-  value        = var.sendgrid_api_key
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "secret_key" {
+#   key          = "secret_key"
+#   value        = var.secret_key
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "default_from_email" {
-  key          = "default_from_email"
-  value        = var.default_from_email
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "sendgrid_api_key" {
+#   key          = "sendgrid_api_key"
+#   value        = var.sendgrid_api_key
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "db_username" {
-  key          = "db_username"
-  value        = var.db_username
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "default_from_email" {
+#   key          = "default_from_email"
+#   value        = var.default_from_email
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "db_password" {
-  key          = "db_password"
-  value        = var.db_password
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "db_username" {
+#   key          = "db_username"
+#   value        = var.db_username
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "vm_admin_username" {
-  key          = "vm_admin_username"
-  value        = var.vm_admin_username
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "db_password" {
+#   key          = "db_password"
+#   value        = var.db_password
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
-resource "tfe_variable" "public_key" {
-  key          = "public_key"
-  value        = var.public_key
-  category     = "terraform"
-  workspace_id = tfe_workspace.infra.id
-  sensitive    = true
-}
+# resource "tfe_variable" "vm_admin_username" {
+#   key          = "vm_admin_username"
+#   value        = var.vm_admin_username
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
+
+# resource "tfe_variable" "public_key" {
+#   key          = "public_key"
+#   value        = var.public_key
+#   category     = "terraform"
+#   workspace_id = tfe_workspace.infra.id
+#   sensitive    = true
+# }
 
 ##################################
 # GitHub
 ##################################
-resource "github_actions_secret" "tf_api_token" {
+# resource "github_actions_secret" "tf_api_token" {
+#   repository      = var.github_repo_name
+#   secret_name     = "TF_API_TOKEN"
+#   encrypted_value = var.tfc_encrypted_token # gh secret set TF_API_TOKEN --no-store
+# }
+
+resource "github_actions_secret" "allowed_cidr" {
   repository      = var.github_repo_name
-  secret_name     = "TF_API_TOKEN"
-  encrypted_value = var.tfc_encrypted_token # gh secret set TF_API_TOKEN --no-store
+  secret_name     = "ALLOWED_CIDR"
+  plaintext_value = var.allowed_cidr
+}
+
+resource "github_actions_secret" "secret_key" {
+  repository      = var.github_repo_name
+  secret_name     = "SECRET_KEY"
+  plaintext_value = var.secret_key
+}
+
+resource "github_actions_secret" "sendgrid_api_key" {
+  repository      = var.github_repo_name
+  secret_name     = "SENDGRID_API_KEY"
+  plaintext_value = var.sendgrid_api_key
+}
+
+resource "github_actions_secret" "default_from_email" {
+  repository      = var.github_repo_name
+  secret_name     = "DEFAULT_FROM_EMAIL"
+  plaintext_value = var.default_from_email
+}
+
+resource "github_actions_secret" "db_username" {
+  repository      = var.github_repo_name
+  secret_name     = "DB_USERNAME"
+  plaintext_value = var.db_username
+}
+
+resource "github_actions_secret" "db_password" {
+  repository      = var.github_repo_name
+  secret_name     = "DB_PASSWORD"
+  plaintext_value = var.db_password
+}
+
+resource "github_actions_secret" "vm_admin_username" {
+  repository      = var.github_repo_name
+  secret_name     = "VM_ADMIN_USERNAME"
+  plaintext_value = var.vm_admin_username
+}
+
+resource "github_actions_secret" "public_key" {
+  repository      = var.github_repo_name
+  secret_name     = "PUBLIC_KEY"
+  plaintext_value = var.public_key
 }

--- a/terraform/trust/variables.tf
+++ b/terraform/trust/variables.tf
@@ -40,7 +40,7 @@ variable "tfc_encrypted_token" {
 
 # Application and Infrastructure
 variable "allowed_cidr" {
-  type = list(string)
+  type = string
 }
 
 variable "secret_key" {


### PR DESCRIPTION
## 背景
ネットワークACLでIPアドレス制限しているAzureリソース（KeyVault、Azure Storage）のデータプレーンを操作するには、Terraform実行環境のグローバルIPアドレスを許可する必要がある。

Terraform Cloudの場合、`data "http" "ipify"` などを利用して自らのIPアドレスを取得して許可リストに加えるよう実装したとしても、うまく許可することができなかった。

apply 実行時にまず `terraform plan` が実行される
1. terraform plan
2. terraform apply

この時、手順1のplanの内容を元に手順2でapplyを実行するが、手順1、手順2でそれぞれ実行環境が作り直されてIPアドレスが異なっているので、手順1のIPを許可しても手順2のapplyは許可されない。

Terraform Cloudにこれを回避する方法があるかどうかは現時点では不明だが、GitHub Actionsで `terraform apply` を実行するように実装を変更してテストする。

## 変更箇所
- `var.allowed_cidr`を文字列に変更（配列はSecretsに登録できなかったのでカンマ区切りの文字列をSplit関数で変換する）
- `var.client_ip_address`を追加
- ipifyのAPIでクライアントIPを取得する処理を追加
- ワークフローのterraformの処理をGithubランナー上で実行するように変更（OIDCで認証）
- Secretsに機密情報の変数を登録

## その他
- Atrantis `atrantis.yaml`を試験的に追加（評価の結果、現時点では利用しない）